### PR TITLE
extensions fix

### DIFF
--- a/utils/md2html.py
+++ b/utils/md2html.py
@@ -29,7 +29,7 @@ def	main(argv):
 		templateText = templateFile.read()
 
 		# Convert markdown source file to HTML
-		htmlContents = markdown.markdown(sourceText, extensions)
+		htmlContents = markdown.markdown(sourceText, extensions=extensions)
 
 		# Get rid of file extension
 		title = getFileName(sourceFileName)


### PR DESCRIPTION
Fixed error:
Traceback (most recent call last):
  File "./utils/md2html.py", line 75, in <module>
    main(sys.argv)
  File "./utils/md2html.py", line 32, in main
    htmlContents = markdown.markdown(sourceText, extensions)
TypeError: markdown() takes exactly 1 argument (2 given)